### PR TITLE
Add HTML resume with print-to-PDF support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ social:
     url: https://scholar.google.com/citations?user=SZ5EErcAAAAJ&sortby=pubdate
   - icon: file-lines
     title: resume
-    url: https://drq.ai/rsc/resume.pdf
+    url: /resume
   - icon: envelope
     title: email
     url: mailto:wesley.chin0919@gmail.com

--- a/resume.html
+++ b/resume.html
@@ -27,12 +27,11 @@ permalink: /resume
             max-width: 100%;
             min-height: 11in;
             margin: 0.4in auto;
-            padding: 0.5in 0.6in;
+            padding: 0.5in;
             background: #fff;
             box-shadow: 0 1px 6px rgba(0,0,0,0.12);
         }
 
-        /* --- Focus & Accessibility --- */
         a:focus-visible {
             outline: 2px solid #2AA198;
             outline-offset: 2px;
@@ -40,9 +39,7 @@ permalink: /resume
         }
 
         @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                transition: none !important;
-            }
+            *, *::before, *::after { transition: none !important; }
         }
 
         /* --- Header --- */
@@ -50,7 +47,7 @@ permalink: /resume
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.08in;
+            margin-bottom: 0.06in;
         }
 
         .header h1 {
@@ -75,11 +72,7 @@ permalink: /resume
 
         .contact a:hover { text-decoration: underline; }
 
-        .contact .links a {
-            color: #2AA198;
-            text-decoration: underline;
-        }
-
+        .contact .links a { color: #2AA198; text-decoration: underline; }
         .contact .links a:hover { color: #208a82; }
 
         /* --- Section Headers --- */
@@ -93,7 +86,7 @@ permalink: /resume
             margin-bottom: 0.06in;
         }
 
-        /* --- Job Entries --- */
+        /* --- Job / Education Entries --- */
         .entry-header {
             display: flex;
             justify-content: space-between;
@@ -106,9 +99,8 @@ permalink: /resume
             font-weight: 700;
         }
 
-        .entry-title .company { font-weight: 400; }
-
         .entry-title a {
+            color: #1a1a1a;
             text-decoration: none;
             transition: opacity 0.15s ease;
         }
@@ -131,13 +123,12 @@ permalink: /resume
 
         .deepmind-blue { color: #0F4ABE; }
 
-        .brand-link { text-decoration: none; font-weight: 400; }
+        .brand-link { text-decoration: none; }
         .brand-link-bold { text-decoration: none; font-weight: 700; }
 
         .teal-link {
             color: #2AA198;
             text-decoration: none;
-            font-weight: 700;
             transition: color 0.15s ease;
         }
         .teal-link:hover { color: #208a82; text-decoration: underline; }
@@ -192,9 +183,7 @@ permalink: /resume
 
         .pub .pub-title { font-weight: 700; }
 
-        .pub .pub-venue {
-            font-style: italic;
-        }
+        .pub .pub-venue { font-style: italic; }
 
         .pub .pub-venue a {
             color: inherit;
@@ -208,9 +197,9 @@ permalink: /resume
         .pub .pub-year { font-style: normal; }
 
         .pub .pub-authors {
-            padding-left: 0.12in;
             font-size: 9.5pt;
             color: #444;
+            line-height: 1.35;
         }
 
         .pub .pub-authors .me {
@@ -241,12 +230,13 @@ permalink: /resume
                 width: auto;
                 min-height: auto;
                 margin: 0;
-                padding: 0.5in 0.6in;
+                padding: 0.5in;
                 box-shadow: none;
             }
 
             a { color: inherit; }
             .contact a, .contact .links a { color: #2d2d2d; }
+            .entry-title a { color: #1a1a1a; }
             .teal-link { color: #2AA198; }
             .deepmind-blue { color: #0F4ABE; }
 
@@ -256,7 +246,6 @@ permalink: /resume
 </head>
 <body>
     <main class="page">
-        <!-- HEADER -->
         <header class="header">
             <h1>Wesley Wei Qian</h1>
             <div class="contact">
@@ -270,13 +259,12 @@ permalink: /resume
             </div>
         </header>
 
-        <!-- EXPERIENCE -->
         <section aria-label="Experience">
         <h2>Experience</h2>
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Founding Team | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/">Osmo</a></span></div>
+                <div class="entry-title">Founding Team | <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/">Osmo</a></div>
                 <div class="entry-date">Sep 2022 - Present</div>
             </div>
             <ul class="bullets">
@@ -290,7 +278,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Student Researcher | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://research.google/" class="brand-link"><span class="google-g">G</span><span class="google-o1">o</span><span class="google-o2">o</span><span class="google-g2">g</span><span class="google-l">l</span><span class="google-e">e</span></a></span></div>
+                <div class="entry-title">Student Researcher | <a target="_blank" rel="noopener noreferrer" href="https://research.google/" class="brand-link"><span class="google-g">G</span><span class="google-o1">o</span><span class="google-o2">o</span><span class="google-g2">g</span><span class="google-l">l</span><span class="google-e">e</span></a></div>
                 <div class="entry-date">May 2018 - Sep 2022</div>
             </div>
             <ul class="bullets">
@@ -302,7 +290,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Intern | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue brand-link-bold">DeepMind</a></span></div>
+                <div class="entry-title">Intern | <a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue brand-link-bold">DeepMind</a></div>
                 <div class="entry-date">Sep 2021 - Dec 2021</div>
             </div>
             <ul class="bullets">
@@ -312,7 +300,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Software Engineering Intern | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://www.uber.com/en-US/blog/engineering/">Uber</a></span></div>
+                <div class="entry-title">Software Engineering Intern | <a target="_blank" rel="noopener noreferrer" href="https://www.uber.com/en-US/blog/engineering/">Uber</a></div>
                 <div class="entry-date">Summer 2016 &amp; 2017</div>
             </div>
             <ul class="bullets">
@@ -322,7 +310,6 @@ permalink: /resume
         </div>
         </section>
 
-        <!-- EDUCATION -->
         <section aria-label="Education">
         <h2>Education</h2>
 
@@ -346,7 +333,6 @@ permalink: /resume
         </div>
         </section>
 
-        <!-- RECENT & SELECTED PUBLICATIONS -->
         <section aria-label="Recent and Selected Publications">
         <h2 class="page-break-before">Recent &amp; Selected Publications <span class="pub-note">(*equal contribution)</span></h2>
 
@@ -399,7 +385,6 @@ permalink: /resume
         </div>
         </section>
 
-        <!-- SERVICES -->
         <section aria-label="Services">
         <h2>Services</h2>
 
@@ -409,7 +394,6 @@ permalink: /resume
         </ul>
         </section>
 
-        <!-- OTHER PUBLICATION -->
         <section aria-label="Other Publications">
         <h2 class="page-break-before">Other Publication</h2>
 

--- a/resume.html
+++ b/resume.html
@@ -10,7 +10,7 @@ permalink: /resume
     <title>Wesley Wei Qian - Resume</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap&font-display=swap" rel="stylesheet">
     <link rel="shortcut icon" href="/img/logo/logo.ico">
     <style>
         /* --- Design Tokens --- */
@@ -130,7 +130,7 @@ permalink: /resume
         .entry-title a:hover { opacity: 0.7; }
 
         /* Brand color overrides for entry links */
-        .entry-title a.deepmind-blue { color: #0F4ABE; }
+        .entry-title a.deepmind-blue { color: #0F4ABE; font-weight: 700; }
         .entry-title a.uiuc-orange { color: #E05500; }
         .entry-title a.uiuc-orange:hover { color: #c04a00; }
         .entry-title a.brandeis-blue { color: #003478; }
@@ -323,7 +323,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Intern | <a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue" style="font-weight:700">DeepMind</a></div>
+                <div class="entry-title">Intern | <a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue">DeepMind</a></div>
                 <div class="entry-date">Sep 2021 - Dec 2021</div>
             </div>
             <ul class="bullets">

--- a/resume.html
+++ b/resume.html
@@ -8,12 +8,15 @@ permalink: /resume
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Wesley Wei Qian - Resume</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="shortcut icon" href="/img/logo/logo.ico">
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font-family: "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             font-size: 10pt;
             line-height: 1.4;
             color: #2d2d2d;
@@ -95,7 +98,7 @@ permalink: /resume
         }
 
         .entry-title {
-            font-size: 10pt;
+            font-size: 10.5pt;
             font-weight: 700;
         }
 
@@ -112,7 +115,7 @@ permalink: /resume
         .entry-title a.teal-link:hover { color: #208a82; }
 
         .entry-date {
-            font-size: 10pt;
+            font-size: 10.5pt;
             white-space: nowrap;
             color: #666;
         }
@@ -152,10 +155,11 @@ permalink: /resume
         }
 
         .bullets li::before {
-            content: "\2023";
+            content: "\25B8";
             position: absolute;
             left: 0;
-            color: #555;
+            color: #2AA198;
+            font-size: 9pt;
         }
 
         .bullets a {
@@ -179,10 +183,12 @@ permalink: /resume
         }
 
         .pub::before {
-            content: "\2023";
+            content: "\2022";
             position: absolute;
             left: 0;
-            color: #555;
+            color: #888;
+            font-size: 8pt;
+            top: 1pt;
         }
 
         .pub .pub-title { font-weight: 700; }
@@ -271,8 +277,8 @@ permalink: /resume
                 <div class="entry-title">Founding Team | <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/">Osmo</a></div>
                 <div class="entry-date">Sep 2022 - Present</div>
             </div>
-            <div style="margin-bottom:1pt">Started as the first research engineer, I am now the VP of Engineering &amp; Research, leading a cross functional team around AI, human data, and software to build 0-to1 prototype and scale AI product.</div>
             <ul class="bullets">
+                <li>Started as the first research engineer, I am now the VP of Engineering &amp; Research, leading a cross functional team around AI, human data, and software to build 0-to1 prototype and scale AI product.</li>
                 <li><strong>LLMs &amp; Agentic Systems:</strong> Architected a multi-modal RAG system <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/turn-words-and-images-into-fragrances">converting text / image briefs into physical fragrance samples</a> (driving &gt;$100k in sales within 3 months). Fine-tuned a formulation LLM using SFT and RLHF with in-house perfumery tools to align outputs with expert preferences.</li>
                 <li><strong>0-1 ML Stack:</strong> Built the post-Google spinout ML stack using PyTorch, GCP, and W&amp;B. Engineered and productionized GNNs and an end-to-end odor intensity pipeline from data collection to deployment that increased discovery throughput by 10×, enabling partnerships with a Top 4 fragrance house.</li>
                 <li><strong>AI for Science:</strong> World in a specialized team of ML researchers and analytical chemists to successfully <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/update-scent-teleportation-we-did-it">"teleport" a physical plum scent</a>; utilized GC-MS analytical data to translate chemical signatures into digital profiles for remote reconstruction — proving "reading scent" is possible.</li>
@@ -348,7 +354,7 @@ permalink: /resume
 
         <div class="pub no-break">
             <div><span class="pub-title">A deep learning and digital archaeology approach for mosquito repellent discovery</span></div>
-            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://pubs.rsc.org/en/content/articlelanding/2025/sc/d4sc06669e">Chemical Science</a></span> <span class="pub-year">(2025)</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://academic.oup.com/chemse/article/doi/10.1093/chemse/bjaf021/8180865">Chemical Science</a></span> <span class="pub-year">(2025)</span></div>
             <div class="pub-authors">Jennifer N. Wei*, Carlos Ruiz*, Marnix Vlot*, Benjamin Sanchez-Lengeling, Brian K. Lee, Luuk Berning, Martijn W. Vos, Rob WM Henderson, <span class="me">Wesley W. Qian</span>, Jacob N. Sanders, D. Michael Ando, Kurt M. Groetsch, Richard C. Gerkin, Alexander B. Wiltschko, Jeffrey A. Riffell, Koen J. Dechering</div>
         </div>
 

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,428 @@
+---
+layout: null
+permalink: /resume
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Wesley Wei Qian - Resume</title>
+    <link rel="shortcut icon" href="/img/logo/logo.ico">
+    <style>
+        /* --- Reset & Base --- */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font-size: 10pt;
+            line-height: 1.4;
+            color: #333;
+            background: #e8e8e8;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        .page {
+            width: 8.5in;
+            min-height: 11in;
+            margin: 0.4in auto;
+            padding: 0.5in 0.6in;
+            background: #fff;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        }
+
+        /* --- Header --- */
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 0.1in;
+        }
+
+        .header h1 {
+            font-size: 24pt;
+            font-weight: 700;
+            color: #222;
+            line-height: 1.1;
+        }
+
+        .contact {
+            text-align: right;
+            font-size: 10pt;
+            line-height: 1.5;
+        }
+
+        .contact a {
+            color: #333;
+            text-decoration: none;
+        }
+
+        .contact a:hover { text-decoration: underline; }
+
+        .contact .links a {
+            color: #2AA198;
+            text-decoration: underline;
+        }
+
+        /* --- Section Headers --- */
+        h2 {
+            font-size: 16pt;
+            font-weight: 300;
+            color: #333;
+            border-bottom: 1.5pt solid #2AA198;
+            padding-bottom: 2pt;
+            margin-top: 0.12in;
+            margin-bottom: 0.06in;
+        }
+
+        /* --- Job Entries --- */
+        .entry-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 1pt;
+        }
+
+        .entry-title {
+            font-size: 10pt;
+            font-weight: 700;
+        }
+
+        .entry-title .company { font-weight: 400; }
+
+        .entry-title a {
+            text-decoration: none;
+        }
+
+        .entry-date {
+            font-size: 10pt;
+            white-space: nowrap;
+            color: #555;
+        }
+
+        /* Brand colors */
+        .google-g { color: #4285F4; }
+        .google-o1 { color: #EA4335; }
+        .google-o2 { color: #FBBC05; }
+        .google-g2 { color: #4285F4; }
+        .google-l { color: #34A853; }
+        .google-e { color: #EA4335; }
+
+        .deepmind-blue { color: #0F4ABE; }
+
+        .brand-link { text-decoration: none; font-weight: 400; }
+        .brand-link-bold { text-decoration: none; font-weight: 700; }
+
+        .teal-link { color: #2AA198; text-decoration: none; font-weight: 700; }
+        .teal-link:hover { text-decoration: underline; }
+
+        /* --- Bullet Lists --- */
+        .bullets {
+            list-style: none;
+            padding-left: 0.15in;
+            margin-bottom: 0.04in;
+        }
+
+        .bullets li {
+            position: relative;
+            padding-left: 0.15in;
+            margin-bottom: 1pt;
+            text-align: justify;
+        }
+
+        .bullets li::before {
+            content: "\2023";
+            position: absolute;
+            left: 0;
+        }
+
+        .bullets a {
+            color: #333;
+            text-decoration: underline;
+        }
+
+        /* --- Education --- */
+        .edu-entry { margin-bottom: 0.04in; }
+
+        .edu-entry .degree {
+            font-style: italic;
+        }
+
+        .edu-entry .details {
+            font-size: 10pt;
+        }
+
+        /* --- Publications --- */
+        .pub {
+            margin-bottom: 0.06in;
+            padding-left: 0.15in;
+            position: relative;
+        }
+
+        .pub::before {
+            content: "\2023";
+            position: absolute;
+            left: 0;
+        }
+
+        .pub .pub-title {
+            font-weight: 700;
+        }
+
+        .pub .pub-venue {
+            text-decoration: underline;
+            font-style: italic;
+        }
+
+        .pub .pub-venue a {
+            color: inherit;
+            text-decoration: underline;
+        }
+
+        .pub .pub-year {
+            font-style: normal;
+        }
+
+        .pub .pub-authors {
+            padding-left: 0.25in;
+            font-size: 9.5pt;
+        }
+
+        .pub .pub-authors .me {
+            font-weight: 700;
+        }
+
+        .pub-note {
+            font-size: 10pt;
+            color: #555;
+            margin-bottom: 0.08in;
+        }
+
+        /* --- Page Break Helpers --- */
+        .page-break-before {
+            break-before: page;
+        }
+
+        .no-break {
+            break-inside: avoid;
+        }
+
+        /* --- Print Styles --- */
+        @page {
+            size: letter;
+            margin: 0;
+        }
+
+        @media print {
+            body {
+                background: none;
+            }
+
+            .page {
+                width: auto;
+                min-height: auto;
+                margin: 0;
+                padding: 0.5in 0.6in;
+                box-shadow: none;
+            }
+
+            a { color: inherit; }
+            .contact a, .contact .links a { color: #333; }
+            .teal-link { color: #2AA198; }
+            .deepmind-blue { color: #0F4ABE; }
+
+            .page-break-before {
+                padding-top: 0.3in;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <!-- HEADER -->
+        <div class="header">
+            <h1>Wesley Wei Qian</h1>
+            <div class="contact">
+                <div><a href="mailto:wesley.chin0919@gmail.com">wesley.chin0919@gmail.com</a></div>
+                <div>617-637-5934</div>
+                <div class="links">
+                    <a target="_blank" rel="noopener noreferrer" href="https://drq.ai">DrQ.ai</a> /
+                    <a target="_blank" rel="noopener noreferrer" href="https://scholar.google.com/citations?user=SZ5EErcAAAAJ&amp;sortby=pubdate">Scholar</a> /
+                    <a target="_blank" rel="noopener noreferrer" href="https://github.com/WesleyyC">GitHub</a>
+                </div>
+            </div>
+        </div>
+
+        <!-- EXPERIENCE -->
+        <h2>Experience</h2>
+
+        <div class="no-break">
+            <div class="entry-header">
+                <div class="entry-title">Founding Team | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/">Osmo</a></span></div>
+                <div class="entry-date">Sep 2022 - Present</div>
+            </div>
+            <ul class="bullets">
+                <li>Started as the first research engineer, I am now the VP of Engineering &amp; Research, leading a cross functional team around AI, human data, and software to build 0-to1 prototype and scale AI product.</li>
+                <li><strong>LLMs &amp; Agentic Systems:</strong> Architected a multi-modal RAG system <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/turn-words-and-images-into-fragrances">converting text/image briefs into physical fragrance samples</a> (driving &gt;$100k in sales within 3 months). Fine-tuned a formulation LLM using SFT and RLHF with in-house perfumery tools to align outputs with expert preferences.</li>
+                <li><strong>0-1 ML Stack:</strong> Built the post-Google spinout ML stack using PyTorch, GCP, and W&amp;B. Engineered and productionized GNNs and an end-to-end odor intensity pipeline from data collection to deployment that increased discovery throughput by 10×, enabling partnerships with a Top 4 fragrance house.</li>
+                <li><strong>AI for Science:</strong> World in a specialized team of ML researchers and analytical chemists to successfully <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/update-scent-teleportation-we-did-it">"teleport" a physical plum scent</a>; utilized GC-MS analytical data to translate chemical signatures into digital profiles for remote reconstruction — proving "reading scent" is possible.</li>
+                <li><strong>Leadership &amp; Product Impact:</strong> Leading a 10+ person cross functional team to build Studio, an AI-agentic fragrance creation platform enabling low-MOQ, rapid turnarounds. Secured a multi-million CPG partnership by demonstrating AI-driven cost reductions and safety improvements in fragrance.</li>
+            </ul>
+        </div>
+
+        <div class="no-break">
+            <div class="entry-header">
+                <div class="entry-title">Student Researcher | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://research.google/" class="brand-link"><span class="google-g">G</span><span class="google-o1">o</span><span class="google-o2">o</span><span class="google-g2">g</span><span class="google-l">l</span><span class="google-e">e</span></a></span></div>
+                <div class="entry-date">May 2018 - Sep 2022</div>
+            </div>
+            <ul class="bullets">
+                <li><strong>Olfactory ML:</strong> Advanced receptor binding prediction and metabolic activity modeling, resulting in one <u>utility patent</u> and four publications featured <a target="_blank" rel="noopener noreferrer" href="https://ai.googleblog.com/2022/09/digitizing-smell-using-molecular-maps.html">in</a> <a target="_blank" rel="noopener noreferrer" href="https://www.quantamagazine.org/ai-model-links-smell-molecules-with-metabolic-processes-20221010/">major</a> <a target="_blank" rel="noopener noreferrer" href="https://www.scientificamerican.com/article/ai-predicts-what-chemicals-will-smell-like-to-a-human/">news</a> <a target="_blank" rel="noopener noreferrer" href="https://blog.google/technology/research/using-new-technology-and-old-books-to-combat-disease/">outlets</a>, catalyzing Osmo's spin out.</li>
+                <li><strong>Genomics &amp; Structural Variants:</strong> Proposed a combinatorial formulation for structural variant calling with ML-based filtering; engineered a ~100× faster read-alignment approach, filed as <a target="_blank" rel="noopener noreferrer" href="https://patents.google.com/patent/WO2022165430A1">a utility patent.</a></li>
+                <li><strong>Generative Cell Images:</strong> Developed a GAN to mitigate batch effects in high-content cell imaging; upstreamed implementations to the <a target="_blank" rel="noopener noreferrer" href="https://blog.tensorflow.org/2019/08/introducing-tf-gan-lightweight-gan.html">TF-GAN library</a> and published findings in Bioinformatics.</li>
+            </ul>
+        </div>
+
+        <div class="no-break">
+            <div class="entry-header">
+                <div class="entry-title">Intern | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue brand-link-bold">DeepMind</a></span></div>
+                <div class="entry-date">Sep 2021 - Dec 2021</div>
+            </div>
+            <ul class="bullets">
+                <li><strong>AlphaFold Team:</strong> Contributed to protein-folding research using JAX and core components of the AlphaFold2 codebase, focusing on representation learning for wide range of prediction tasks.</li>
+            </ul>
+        </div>
+
+        <div class="no-break">
+            <div class="entry-header">
+                <div class="entry-title">Software Engineering Intern | <span class="company"><a target="_blank" rel="noopener noreferrer" href="https://www.uber.com/en-US/blog/engineering/">Uber</a></span></div>
+                <div class="entry-date">Summer 2016 &amp; 2017</div>
+            </div>
+            <ul class="bullets">
+                <li><strong>[2017] Sensor &amp; Machine Learning:</strong> Built a Conditional Random Field (CRF) variant to infer Uber Eats delivery events from mobile sensor data. Won 1st place at Uber's internal ML poster session for identifying and resolving critical upstream data-quality issues.</li>
+                <li><strong>[2016] Mobile Dev. &amp; Engineering:</strong> Developed a web-based forensics tool for mobile UI testing that synchronized logs with video timestamps, reducing internal developer debugging time by ~50%.</li>
+            </ul>
+        </div>
+
+        <!-- EDUCATION -->
+        <h2>Education</h2>
+
+        <div class="edu-entry no-break">
+            <div class="entry-header">
+                <div class="entry-title"><a class="teal-link" target="_blank" rel="noopener noreferrer" href="https://cs.illinois.edu/">University of Illinois Urbana Champaign</a></div>
+                <div class="entry-date">2017 - 2022</div>
+            </div>
+            <div class="degree">Doctor of Philosophy in Computer Science</div>
+            <div class="details">Dissertation: Machine learning for drug discovery and beyond (advisor: <em>Jian Peng</em>)</div>
+            <div class="details">GPA: 4.00 / 4.00 | University Fellowship | Richard T. Cheng Endowed Fellowship</div>
+        </div>
+
+        <div class="edu-entry no-break">
+            <div class="entry-header">
+                <div class="entry-title"><a class="teal-link" target="_blank" rel="noopener noreferrer" href="https://www.brandeis.edu/">Brandeis University</a></div>
+                <div class="entry-date">2013 - 2017</div>
+            </div>
+            <div class="degree">Bachelor of Science in Computer Science and Neuroscience</div>
+            <div class="details">GPA: 3.96 / 4.00 | Summa Cum Laude | Phi Beta Kappa (Junior) | Schiff Fellowship</div>
+        </div>
+
+        <!-- RECENT & SELECTED PUBLICATIONS -->
+        <h2 class="page-break-before">Recent &amp; Selected Publications <span class="pub-note">(*equal contribution)</span></h2>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">New York Smells: A Large Multimodal Dataset for Olfaction</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://arxiv.org/abs/2511.20544">arXiv</a></span> <span class="pub-year">(2025)</span></div>
+            <div class="pub-authors">Ege Ozguroglu, Junbang Liang, Ruoshi Liu, Mia Chiquier, Michael DeTienne, <span class="me">Wesley W.Qian</span>, Alexandra Horowitz, Andrew Owens, Carl Vondrick</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">A deep learning and digital archaeology approach for mosquito repellent discovery</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://academic.oup.com/chemse/article/doi/10.1093/chemse/bjaf021/8180865">Chemical Science</a></span> <span class="pub-year">(2025)</span></div>
+            <div class="pub-authors">Jennifer N. Wei*, Carlos Ruiz*, Marnix Vlot*, Benjamin Sanchez-Lengeling, Brian K. Lee, Luuk Berning, Martijn W. Vos, Rob WM Henderson, <span class="me">Wesley W. Qian</span>, Jacob N. Sanders, D. Michael Ando, Kurt M. Groetsch, Richard C. Gerkin, Alexander B. Wiltschko, Jeffrey A. Riffell, Koen J. Dechering</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">A Principal Odor Map Unifies Diverse Tasks in Human Olfactory Perception</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.science.org/doi/10.1126/science.ade4401">Science</a></span> <span class="pub-year">(2023)</span></div>
+            <div class="pub-authors">Brian K. Lee*, Emily E Mayhew*, Benjamin Sanchez-Lengeling, Jennifer N. Wei, <span class="me">Wesley W. Qian</span>, Kelsie Little, Matthew Andres, Britney B. Nguyen, Theresa Moloy, Jacob Yasonik, Jane K. Parker, Richard C. Gerkin, Joel D. Mainland, Alexander B. Wiltschko</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Metabolic activity organizes olfactory representations</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://elifesciences.org/articles/82502">eLife</a></span> <span class="pub-year">(2023)</span></div>
+            <div class="pub-authors"><span class="me">Wesley W. Qian</span>, Jennifer N. Wei, Benjamin Sanchez-Lengeling, Brian K. Lee, Yunan Luo, Marnix Vlot, Koen Dechering, Jian Peng, Richard C. Gerkin, Alexander B. Wiltschko</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">3D Equivariant Diffusion for Target-Aware Molecule Generation and Affinity Prediction</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://iclr.cc/virtual/2023/poster/11022">ICLR</a></span> <span class="pub-year">(2023)</span></div>
+            <div class="pub-authors">Jiaqi Guan*, <span class="me">Wesley W. Qian</span>*, Xingang Peng, Yufeng Su, Jian Peng, Jianzhu Ma</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Energy-Inspired Molecular Conformation Optimization</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://iclr.cc/virtual/2022/poster/6692">ICLR</a></span> <span class="pub-year">(2022)</span></div>
+            <div class="pub-authors">Jiaqi Guan*, <span class="me">Wesley W. Qian</span>*, Qiang Liu, Wei-Ying Ma, Jianzhu Ma, Jian Peng</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Integrating Deep Neural Networks and Symbolic Inference for Organic Reactivity Prediction</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://chemrxiv.org/doi/full/10.26434/chemrxiv.11659563.v1">ACS National Meeting</a></span> <span class="pub-year">(2021)</span></div>
+            <div class="pub-authors"><span class="me">Wesley W. Qian</span>*, Nathan T. Russell*, Claire L. W. Simons, Yunan Luo, Martin D. Burke, Jian Peng</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Batch Equalization with a Generative Adversarial Network</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://academic.oup.com/bioinformatics/article/36/Supplement_2/i875/6055901">Bioinformatics</a></span> <span class="pub-year">(2020)</span></div>
+            <div class="pub-authors"><span class="me">Wesley W. Qian</span>, Cassandra Xia, Subhashini Venugopalan, Arunachalam Narayanaswamy, Michelle Dimon, George W. Ashdown, Jake Baum, Jian Peng, D Michael Ando</div>
+        </div>
+
+        <!-- SERVICES -->
+        <h2>Services</h2>
+
+        <ul class="bullets">
+            <li><strong>Reviewer</strong> for Nature Machine Intelligence (2025), ICML (2024), ICLR (2024), NeurIPS (2023), LoG (2022 &amp; 2023), RECOMB (2021), ISMB (2019 &amp; 2020)</li>
+            <li><strong>Program Committee</strong> for ICML - ML Interpretability for Scientific Discovery Workshop 2020</li>
+        </ul>
+
+        <!-- OTHER PUBLICATION -->
+        <h2 class="page-break-before">Other Publication</h2>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Pervasive mislocalization of pathogenic coding variants underlying human disorders</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.cell.com/cell/fulltext/S0092-8674(24)01021-3">Cell</a></span> <span class="pub-year">(2024)</span></div>
+            <div class="pub-authors">Jessica Lacoste, Marzieh Haghighi, Shahan Haider, Chloe Reno, Zhen-Yuan Lin, Dmitri Segal, <span class="me">Wesley W. Qian</span>, Xueting Xiong, Tanisha Teelucksingh, Esteban Miglietta, Hamdah Shafqat-Abbasi, Pearl V. Ryder, Rebecca Senft, Beth A. Cimini, Ryan R. Murray, Chantal Nyirakanani, Tong Hao, Gregory G. McClain, Frederick P. Roth, Michael A. Calderwood, David E. Hill, Marc Vidal, S Stephen Yi, Nidhi Sahni, Jian Peng, Anne-Claude Gingras, Shantanu Singh, Anne E. Carpenter, Mikko Taipale</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">A central chaperone-like role for 14-3-3 proteins in human cells</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.cell.com/molecular-cell/fulltext/S1097-2765(23)00121-1">Molecular Cell</a></span> <span class="pub-year">(2023)</span></div>
+            <div class="pub-authors">Dmitri Segal, Stefan Maier, Giovanni J Mastromarco, <span class="me">Wesley W. Qian</span>, Syed Nabeel-Shah, Hyunmin Lee, Gaelen Moore, Jessica Lacoste, Brett Larsen, Zhen-Yuan Lin, Abeeshan Selvabaskaran, Karen Liu, Craig Smibert, Zhaolei Zhang, Jack Greenblatt, Jian Peng, Hyun O Lee, Anne-Claude Gingras, Mikko Taipale</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">ECNet is an evolutionary context-integrated deep learning framework for protein engineering</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.nature.com/articles/s41467-021-25976-8">Nature Communication</a></span> <span class="pub-year">(2021)</span></div>
+            <div class="pub-authors">Yunan Luo, Guangde Jiang, Tianhao Yu, Yang Liu, Lam Vo, Hantian Ding, Yufeng Su, <span class="me">Wesley W. Qian</span>, Huimin Zhao, Jian Peng</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Comprehensive interactome profiling of the human Hsp70 network highlights functional differentiation of J domains</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.cell.com/molecular-cell/fulltext/S1097-2765(21)00317-8">Molecular Cell</a></span> <span class="pub-year">(2021)</span></div>
+            <div class="pub-authors">Benjamin L. Piette, Nader Alerasool, Zhen-Yuan Lin, Jessica Lacoste, Mandy Hiu Yi Lam, <span class="me">Wesley W. Qian</span>, Stephanie Tran, Brett Larsen, Eric Campos, Jian Peng, Anne-Claude Gingras, Mikko Taipale</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Evaluating Attribution for Graph Neural Networks</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://papers.nips.cc/paper/2020/hash/417fbbf2e9d5a28a855a11894b2e795a-Abstract.html">NeurIPS</a></span> <span class="pub-year">(2020)</span></div>
+            <div class="pub-authors">Benjamin Sanchez-Lengeling, Jennifer Wei, Brian Lee, Emily Reif, Peter Wang, <span class="me">Wesley W. Qian</span>, Kevin McCloskey, Lucy Colwell, Alexander B. Wiltschko</div>
+        </div>
+
+        <div class="pub no-break">
+            <div><span class="pub-title">Evolutionary context-integrated deep sequence modeling for protein engineering</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://dl.acm.org/doi/10.1007/978-3-030-45257-5_30">RECOMB</a></span> <span class="pub-year">(2020)</span></div>
+            <div class="pub-authors">Yunan Luo, Lam Vo, Hantian Ding, Yufeng Su, Yang Liu, <span class="me">Wesley W. Qian</span>, Huimin Zhao, Jian Peng</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resume.html
+++ b/resume.html
@@ -78,6 +78,13 @@ permalink: /resume
             color: var(--color-text-dark);
             line-height: 1.1;
             letter-spacing: -0.01em;
+            transition: transform 0.2s var(--ease-out-quart), text-shadow 0.2s ease;
+            cursor: default;
+        }
+
+        .header h1:hover {
+            transform: translateY(-2px);
+            text-shadow: 0 4px 12px rgba(42, 161, 152, 0.15);
         }
 
         .contact {
@@ -189,6 +196,12 @@ permalink: /resume
             margin-bottom: 0.05in;
             padding-left: 0.15in;
             position: relative;
+            border-left: 2pt solid transparent;
+            transition: border-color 0.15s var(--ease-out-quart);
+        }
+
+        .pub:hover {
+            border-left-color: var(--color-accent);
         }
 
         .pub::before {
@@ -274,6 +287,11 @@ permalink: /resume
             .entry-title a.brandeis-blue { color: #003478; }
 
             .page-break-before { padding-top: 0.5in; }
+
+            .header h1 { transition: none; }
+            .header h1:hover { transform: none; text-shadow: none; }
+            .pub { border-left: none; }
+            .pub:hover { border-left: none; }
         }
     </style>
 </head>
@@ -467,5 +485,18 @@ permalink: /resume
         </ul>
         </section>
     </main>
+    <!-- For the curious: this resume was hand-crafted in HTML, not exported from a PDF.
+         Wesley believes the best tools are the ones you build yourself. -->
+    <script>
+    if (typeof console !== 'undefined') {
+        console.log('%cHi there! %cCurious about how this resume was built?',
+            'font-size:14px;font-weight:700;color:#2AA198',
+            'font-size:14px;color:#2d2d2d');
+        console.log('%cIt\'s a single HTML file with pure CSS print styles. No frameworks, no build tools.',
+            'font-size:12px;color:#666');
+        console.log('%cSource: https://github.com/WesleyyC/wesleyyc.github.io/blob/master/resume.html',
+            'font-size:12px;color:#2AA198');
+    }
+    </script>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -114,8 +114,10 @@ permalink: /resume
         .entry-title a.teal-link { color: #2AA198; }
         .entry-title a.teal-link:hover { color: #208a82; }
 
-        .uiuc-orange { color: #E05500; }
-        .brandeis-blue { color: #003478; }
+        .entry-title a.uiuc-orange { color: #E05500; }
+        .entry-title a.uiuc-orange:hover { color: #c04a00; }
+        .entry-title a.brandeis-blue { color: #003478; }
+        .entry-title a.brandeis-blue:hover { color: #002a60; }
 
         .entry-date {
             font-size: 11pt;
@@ -194,7 +196,7 @@ permalink: /resume
             top: 1pt;
         }
 
-        .pub .pub-title { font-weight: 700; }
+        .pub .pub-title { font-weight: 700; font-size: 10.5pt; }
 
         .pub .pub-venue { font-style: italic; }
 
@@ -250,10 +252,10 @@ permalink: /resume
             a { color: inherit; }
             .contact a, .contact .links a { color: #2d2d2d; }
             .entry-title a { color: #1a1a1a; }
+            .entry-title a.deepmind-blue { color: #0F4ABE; }
+            .entry-title a.uiuc-orange { color: #E05500; }
+            .entry-title a.brandeis-blue { color: #003478; }
             .teal-link { color: #2AA198; }
-            .deepmind-blue { color: #0F4ABE; }
-            .uiuc-orange { color: #E05500; }
-            .brandeis-blue { color: #003478; }
 
             .page-break-before { padding-top: 0.3in; }
         }
@@ -330,7 +332,7 @@ permalink: /resume
 
         <div class="edu-entry no-break">
             <div class="entry-header">
-                <div class="entry-title"><a class="uiuc-orange" target="_blank" rel="noopener noreferrer" href="https://cs.illinois.edu/" style="text-decoration:none;font-weight:700">University of Illinois Urbana Champaign</a></div>
+                <div class="entry-title"><a class="uiuc-orange" target="_blank" rel="noopener noreferrer" href="https://cs.illinois.edu/">University of Illinois Urbana Champaign</a></div>
                 <div class="entry-date">2017 - 2022</div>
             </div>
             <div class="degree">Doctor of Philosophy in Computer Science</div>
@@ -340,7 +342,7 @@ permalink: /resume
 
         <div class="edu-entry no-break">
             <div class="entry-header">
-                <div class="entry-title"><a class="brandeis-blue" target="_blank" rel="noopener noreferrer" href="https://www.brandeis.edu/" style="text-decoration:none;font-weight:700">Brandeis University</a></div>
+                <div class="entry-title"><a class="brandeis-blue" target="_blank" rel="noopener noreferrer" href="https://www.brandeis.edu/">Brandeis University</a></div>
                 <div class="entry-date">2013 - 2017</div>
             </div>
             <div class="degree">Bachelor of Science in Computer Science and Neuroscience</div>
@@ -421,7 +423,7 @@ permalink: /resume
             <div class="pub-authors">Yunan Luo, Guangde Jiang, Tianhao Yu, Yang Liu, Lam Vo, Hantian Ding, Yufeng Su, <span class="me">Wesley W. Qian</span>, Huimin Zhao, Jian Peng</div>
         </div>
 
-        <div class="pub no-break">
+        <div class="pub no-break page-break-before">
             <div><span class="pub-title">Comprehensive interactome profiling of the human Hsp70 network highlights functional differentiation of J domains</span></div>
             <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://www.cell.com/molecular-cell/fulltext/S1097-2765(21)00317-8">Molecular Cell</a></span> <span class="pub-year">(2021)</span></div>
             <div class="pub-authors">Benjamin L. Piette, Nader Alerasool, Zhen-Yuan Lin, Jessica Lacoste, Mandy Hiu Yi Lam, <span class="me">Wesley W. Qian</span>, Stephanie Tran, Brett Larsen, Eric Campos, Jian Peng, Anne-Claude Gingras, Mikko Taipale</div>

--- a/resume.html
+++ b/resume.html
@@ -198,12 +198,6 @@ permalink: /resume
             margin-bottom: 0.05in;
             padding-left: 0.15in;
             position: relative;
-            border-left: 2pt solid transparent;
-            transition: border-color 0.15s var(--ease-out-quart);
-        }
-
-        .pub:hover {
-            border-left-color: var(--color-accent);
         }
 
         .pub::before {
@@ -255,11 +249,14 @@ permalink: /resume
             letter-spacing: normal;
         }
 
-        /* --- Services (grey bullets like publications) --- */
+        /* --- Services (match publication indentation + grey bullets) --- */
+        .service-bullets { padding-left: 0; }
+        .service-bullets li { padding-left: 0.15in; }
         .service-bullets li::before {
             content: "\2022";
             color: var(--color-bullet-muted);
             font-size: 8pt;
+            top: 1pt;
         }
 
         /* --- Page Break Helpers --- */
@@ -294,8 +291,6 @@ permalink: /resume
 
             .header h1 { transition: none; }
             .header h1:hover { transform: none; text-shadow: none; }
-            .pub { border-left: none; }
-            .pub:hover { border-left: none; }
         }
     </style>
 </head>

--- a/resume.html
+++ b/resume.html
@@ -113,7 +113,6 @@ permalink: /resume
         .entry-title a.deepmind-blue { color: #0F4ABE; }
         .entry-title a.teal-link { color: #2AA198; }
         .entry-title a.teal-link:hover { color: #208a82; }
-
         .entry-title a.uiuc-orange { color: #E05500; }
         .entry-title a.uiuc-orange:hover { color: #c04a00; }
         .entry-title a.brandeis-blue { color: #003478; }
@@ -182,7 +181,7 @@ permalink: /resume
 
         /* --- Publications --- */
         .pub {
-            margin-bottom: 0.06in;
+            margin-bottom: 0.05in;
             padding-left: 0.15in;
             position: relative;
         }
@@ -196,9 +195,12 @@ permalink: /resume
             top: 1pt;
         }
 
-        .pub .pub-title { font-weight: 700; font-size: 10.5pt; }
+        .pub .pub-title { font-weight: 700; }
 
-        .pub .pub-venue { font-style: italic; }
+        .pub .pub-venue {
+            font-style: italic;
+            color: #555;
+        }
 
         .pub .pub-venue a {
             color: inherit;
@@ -209,12 +211,15 @@ permalink: /resume
 
         .pub .pub-venue a:hover { color: #2AA198; }
 
-        .pub .pub-year { font-style: normal; }
+        .pub .pub-year {
+            font-style: normal;
+            color: #555;
+        }
 
         .pub .pub-authors {
-            font-size: 9.5pt;
-            color: #444;
-            line-height: 1.35;
+            font-size: 9pt;
+            color: #666;
+            line-height: 1.3;
         }
 
         .pub .pub-authors .me {
@@ -224,8 +229,15 @@ permalink: /resume
 
         .pub-note {
             font-size: 10pt;
-            font-weight: 300;
-            color: #666;
+            font-weight: 400;
+            color: #888;
+        }
+
+        /* --- Services (use grey bullets like publications) --- */
+        .service-bullets li::before {
+            content: "\2022";
+            color: #888;
+            font-size: 8pt;
         }
 
         /* --- Page Break Helpers --- */
@@ -258,6 +270,7 @@ permalink: /resume
             .teal-link { color: #2AA198; }
 
             .page-break-before { padding-top: 0.5in; }
+
         }
     </style>
 </head>
@@ -445,7 +458,7 @@ permalink: /resume
         <section aria-label="Services">
         <h2>Services</h2>
 
-        <ul class="bullets">
+        <ul class="bullets service-bullets">
             <li><strong>Reviewer</strong> for Nature Machine Intelligence (2025), ICML (2024), ICLR (2024), NeurIPS (2023), LoG (2022 &amp; 2023), RECOMB (2021), ISMB (2019 &amp; 2020)</li>
             <li><strong>Program Committee</strong> for ICML - ML Interpretability for Scientific Discovery Workshop 2020</li>
         </ul>

--- a/resume.html
+++ b/resume.html
@@ -257,7 +257,7 @@ permalink: /resume
             .entry-title a.brandeis-blue { color: #003478; }
             .teal-link { color: #2AA198; }
 
-            .page-break-before { padding-top: 0.3in; }
+            .page-break-before { padding-top: 0.5in; }
         }
     </style>
 </head>

--- a/resume.html
+++ b/resume.html
@@ -107,6 +107,10 @@ permalink: /resume
 
         .entry-title a:hover { opacity: 0.7; }
 
+        .entry-title a.deepmind-blue { color: #0F4ABE; }
+        .entry-title a.teal-link { color: #2AA198; }
+        .entry-title a.teal-link:hover { color: #208a82; }
+
         .entry-date {
             font-size: 10pt;
             white-space: nowrap;
@@ -267,9 +271,9 @@ permalink: /resume
                 <div class="entry-title">Founding Team | <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/">Osmo</a></div>
                 <div class="entry-date">Sep 2022 - Present</div>
             </div>
+            <div style="margin-bottom:1pt">Started as the first research engineer, I am now the VP of Engineering &amp; Research, leading a cross functional team around AI, human data, and software to build 0-to1 prototype and scale AI product.</div>
             <ul class="bullets">
-                <li>Started as the first research engineer, I am now the VP of Engineering &amp; Research, leading a cross functional team around AI, human data, and software to build 0-to1 prototype and scale AI product.</li>
-                <li><strong>LLMs &amp; Agentic Systems:</strong> Architected a multi-modal RAG system <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/turn-words-and-images-into-fragrances">converting text/image briefs into physical fragrance samples</a> (driving &gt;$100k in sales within 3 months). Fine-tuned a formulation LLM using SFT and RLHF with in-house perfumery tools to align outputs with expert preferences.</li>
+                <li><strong>LLMs &amp; Agentic Systems:</strong> Architected a multi-modal RAG system <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/turn-words-and-images-into-fragrances">converting text / image briefs into physical fragrance samples</a> (driving &gt;$100k in sales within 3 months). Fine-tuned a formulation LLM using SFT and RLHF with in-house perfumery tools to align outputs with expert preferences.</li>
                 <li><strong>0-1 ML Stack:</strong> Built the post-Google spinout ML stack using PyTorch, GCP, and W&amp;B. Engineered and productionized GNNs and an end-to-end odor intensity pipeline from data collection to deployment that increased discovery throughput by 10×, enabling partnerships with a Top 4 fragrance house.</li>
                 <li><strong>AI for Science:</strong> World in a specialized team of ML researchers and analytical chemists to successfully <a target="_blank" rel="noopener noreferrer" href="https://www.osmo.ai/blog/update-scent-teleportation-we-did-it">"teleport" a physical plum scent</a>; utilized GC-MS analytical data to translate chemical signatures into digital profiles for remote reconstruction — proving "reading scent" is possible.</li>
                 <li><strong>Leadership &amp; Product Impact:</strong> Leading a 10+ person cross functional team to build Studio, an AI-agentic fragrance creation platform enabling low-MOQ, rapid turnarounds. Secured a multi-million CPG partnership by demonstrating AI-driven cost reductions and safety improvements in fragrance.</li>
@@ -344,7 +348,7 @@ permalink: /resume
 
         <div class="pub no-break">
             <div><span class="pub-title">A deep learning and digital archaeology approach for mosquito repellent discovery</span></div>
-            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://academic.oup.com/chemse/article/doi/10.1093/chemse/bjaf021/8180865">Chemical Science</a></span> <span class="pub-year">(2025)</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://pubs.rsc.org/en/content/articlelanding/2025/sc/d4sc06669e">Chemical Science</a></span> <span class="pub-year">(2025)</span></div>
             <div class="pub-authors">Jennifer N. Wei*, Carlos Ruiz*, Marnix Vlot*, Benjamin Sanchez-Lengeling, Brian K. Lee, Luuk Berning, Martijn W. Vos, Rob WM Henderson, <span class="me">Wesley W. Qian</span>, Jacob N. Sanders, D. Michael Ando, Kurt M. Groetsch, Richard C. Gerkin, Alexander B. Wiltschko, Jeffrey A. Riffell, Koen J. Dechering</div>
         </div>
 
@@ -385,15 +389,6 @@ permalink: /resume
         </div>
         </section>
 
-        <section aria-label="Services">
-        <h2>Services</h2>
-
-        <ul class="bullets">
-            <li><strong>Reviewer</strong> for Nature Machine Intelligence (2025), ICML (2024), ICLR (2024), NeurIPS (2023), LoG (2022 &amp; 2023), RECOMB (2021), ISMB (2019 &amp; 2020)</li>
-            <li><strong>Program Committee</strong> for ICML - ML Interpretability for Scientific Discovery Workshop 2020</li>
-        </ul>
-        </section>
-
         <section aria-label="Other Publications">
         <h2 class="page-break-before">Other Publication</h2>
 
@@ -432,6 +427,15 @@ permalink: /resume
             <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://dl.acm.org/doi/10.1007/978-3-030-45257-5_30">RECOMB</a></span> <span class="pub-year">(2020)</span></div>
             <div class="pub-authors">Yunan Luo, Lam Vo, Hantian Ding, Yufeng Su, Yang Liu, <span class="me">Wesley W. Qian</span>, Huimin Zhao, Jian Peng</div>
         </div>
+        </section>
+
+        <section aria-label="Services">
+        <h2>Services</h2>
+
+        <ul class="bullets">
+            <li><strong>Reviewer</strong> for Nature Machine Intelligence (2025), ICML (2024), ICLR (2024), NeurIPS (2023), LoG (2022 &amp; 2023), RECOMB (2021), ISMB (2019 &amp; 2020)</li>
+            <li><strong>Program Committee</strong> for ICML - ML Interpretability for Scientific Discovery Workshop 2020</li>
+        </ul>
         </section>
     </main>
 </body>

--- a/resume.html
+++ b/resume.html
@@ -13,14 +13,32 @@ permalink: /resume
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="shortcut icon" href="/img/logo/logo.ico">
     <style>
+        /* --- Design Tokens --- */
+        :root {
+            --color-text: #2d2d2d;
+            --color-text-dark: #1a1a1a;
+            --color-text-muted: #666;
+            --color-text-light: #777;
+            --color-accent: #2AA198;
+            --color-accent-hover: #208a82;
+            --color-bg: #e4e4e4;
+            --color-page: #fff;
+            --color-bullet-muted: #888;
+            --color-author: #666;
+            --color-venue: #555;
+            --font-body: "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+        }
+
+        /* --- Reset & Base --- */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
-            font-family: "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font-family: var(--font-body);
             font-size: 10pt;
             line-height: 1.4;
-            color: #2d2d2d;
-            background: #e4e4e4;
+            color: var(--color-text);
+            background: var(--color-bg);
             -webkit-print-color-adjust: exact;
             print-color-adjust: exact;
         }
@@ -31,12 +49,13 @@ permalink: /resume
             min-height: 11in;
             margin: 0.4in auto;
             padding: 0.5in;
-            background: #fff;
+            background: var(--color-page);
             box-shadow: 0 1px 6px rgba(0,0,0,0.12);
         }
 
+        /* --- Accessibility --- */
         a:focus-visible {
-            outline: 2px solid #2AA198;
+            outline: 2px solid var(--color-accent);
             outline-offset: 2px;
             border-radius: 2px;
         }
@@ -56,7 +75,7 @@ permalink: /resume
         .header h1 {
             font-size: 24pt;
             font-weight: 700;
-            color: #1a1a1a;
+            color: var(--color-text-dark);
             line-height: 1.1;
             letter-spacing: -0.01em;
         }
@@ -68,28 +87,28 @@ permalink: /resume
         }
 
         .contact a {
-            color: #2d2d2d;
+            color: var(--color-text);
             text-decoration: none;
-            transition: color 0.15s ease;
+            transition: color 0.15s var(--ease-out-quart);
         }
 
         .contact a:hover { text-decoration: underline; }
 
-        .contact .links a { color: #2AA198; text-decoration: underline; }
-        .contact .links a:hover { color: #208a82; }
+        .contact .links a { color: var(--color-accent); text-decoration: underline; }
+        .contact .links a:hover { color: var(--color-accent-hover); }
 
         /* --- Section Headers --- */
         h2 {
             font-size: 15pt;
-            font-weight: 300;
-            color: #2d2d2d;
-            border-bottom: 1.5pt solid #2AA198;
+            font-weight: 400;
+            color: var(--color-text);
+            border-bottom: 1.5pt solid var(--color-accent);
             padding-bottom: 2pt;
             margin-top: 0.12in;
             margin-bottom: 0.06in;
         }
 
-        /* --- Job / Education Entries --- */
+        /* --- Entry Headers (Jobs, Education) --- */
         .entry-header {
             display: flex;
             justify-content: space-between;
@@ -103,16 +122,15 @@ permalink: /resume
         }
 
         .entry-title a {
-            color: #1a1a1a;
+            color: var(--color-text-dark);
             text-decoration: none;
-            transition: opacity 0.15s ease;
+            transition: opacity 0.15s var(--ease-out-quart);
         }
 
         .entry-title a:hover { opacity: 0.7; }
 
+        /* Brand color overrides for entry links */
         .entry-title a.deepmind-blue { color: #0F4ABE; }
-        .entry-title a.teal-link { color: #2AA198; }
-        .entry-title a.teal-link:hover { color: #208a82; }
         .entry-title a.uiuc-orange { color: #E05500; }
         .entry-title a.uiuc-orange:hover { color: #c04a00; }
         .entry-title a.brandeis-blue { color: #003478; }
@@ -121,30 +139,17 @@ permalink: /resume
         .entry-date {
             font-size: 11pt;
             white-space: nowrap;
-            color: #666;
+            color: var(--color-text-muted);
         }
 
         /* --- Brand Colors --- */
-        .google-g { color: #4285F4; }
-        .google-o1 { color: #EA4335; }
+        .google-g, .google-g2 { color: #4285F4; }
+        .google-o1, .google-e { color: #EA4335; }
         .google-o2 { color: #E2A000; }
-        .google-g2 { color: #4285F4; }
         .google-l { color: #34A853; }
-        .google-e { color: #EA4335; }
-
         .deepmind-blue { color: #0F4ABE; }
 
-        .brand-link { text-decoration: none; }
-        .brand-link-bold { text-decoration: none; font-weight: 700; }
-
-        .teal-link {
-            color: #2AA198;
-            text-decoration: none;
-            transition: color 0.15s ease;
-        }
-        .teal-link:hover { color: #208a82; text-decoration: underline; }
-
-        /* --- Bullet Lists --- */
+        /* --- Bullet Lists (Experience) --- */
         .bullets {
             list-style: none;
             padding-left: 0.15in;
@@ -162,18 +167,18 @@ permalink: /resume
             content: "\25B8";
             position: absolute;
             left: 0;
-            color: #2AA198;
+            color: var(--color-accent);
             font-size: 9pt;
         }
 
         .bullets a {
-            color: #2d2d2d;
+            color: var(--color-text);
             text-decoration: underline;
             text-underline-offset: 1.5pt;
-            transition: color 0.15s ease;
+            transition: color 0.15s var(--ease-out-quart);
         }
 
-        .bullets a:hover { color: #2AA198; }
+        .bullets a:hover { color: var(--color-accent); }
 
         /* --- Education --- */
         .edu-entry { margin-bottom: 0.04in; }
@@ -190,7 +195,7 @@ permalink: /resume
             content: "\2022";
             position: absolute;
             left: 0;
-            color: #888;
+            color: var(--color-bullet-muted);
             font-size: 8pt;
             top: 1pt;
         }
@@ -199,44 +204,44 @@ permalink: /resume
 
         .pub .pub-venue {
             font-style: italic;
-            color: #555;
+            color: var(--color-venue);
         }
 
         .pub .pub-venue a {
             color: inherit;
             text-decoration: underline;
             text-underline-offset: 1.5pt;
-            transition: color 0.15s ease;
+            transition: color 0.15s var(--ease-out-quart);
         }
 
-        .pub .pub-venue a:hover { color: #2AA198; }
+        .pub .pub-venue a:hover { color: var(--color-accent); }
 
         .pub .pub-year {
             font-style: normal;
-            color: #555;
+            color: var(--color-venue);
         }
 
         .pub .pub-authors {
             font-size: 9pt;
-            color: #666;
+            color: var(--color-author);
             line-height: 1.3;
         }
 
         .pub .pub-authors .me {
-            font-weight: 700;
-            color: #2d2d2d;
+            font-weight: 600;
+            color: var(--color-text);
         }
 
         .pub-note {
             font-size: 10pt;
             font-weight: 400;
-            color: #888;
+            color: var(--color-text-light);
         }
 
-        /* --- Services (use grey bullets like publications) --- */
+        /* --- Services (grey bullets like publications) --- */
         .service-bullets li::before {
             content: "\2022";
-            color: #888;
+            color: var(--color-bullet-muted);
             font-size: 8pt;
         }
 
@@ -244,7 +249,7 @@ permalink: /resume
         .page-break-before { break-before: page; }
         .no-break { break-inside: avoid; }
 
-        /* --- Print Styles --- */
+        /* --- Print --- */
         @page {
             size: letter;
             margin: 0;
@@ -262,15 +267,13 @@ permalink: /resume
             }
 
             a { color: inherit; }
-            .contact a, .contact .links a { color: #2d2d2d; }
-            .entry-title a { color: #1a1a1a; }
+            .contact a, .contact .links a { color: var(--color-text); }
+            .entry-title a { color: var(--color-text-dark); }
             .entry-title a.deepmind-blue { color: #0F4ABE; }
             .entry-title a.uiuc-orange { color: #E05500; }
             .entry-title a.brandeis-blue { color: #003478; }
-            .teal-link { color: #2AA198; }
 
             .page-break-before { padding-top: 0.5in; }
-
         }
     </style>
 </head>
@@ -282,8 +285,8 @@ permalink: /resume
                 <div><a href="mailto:wesley.chin0919@gmail.com">wesley.chin0919@gmail.com</a></div>
                 <div>617-637-5934</div>
                 <div class="links">
-                    <a target="_blank" rel="noopener noreferrer" href="https://drq.ai">DrQ.ai</a> /
-                    <a target="_blank" rel="noopener noreferrer" href="https://scholar.google.com/citations?user=SZ5EErcAAAAJ&amp;sortby=pubdate">Scholar</a> /
+                    <a target="_blank" rel="noopener noreferrer" href="https://drq.ai">DrQ.ai</a> &middot;
+                    <a target="_blank" rel="noopener noreferrer" href="https://scholar.google.com/citations?user=SZ5EErcAAAAJ&amp;sortby=pubdate">Scholar</a> &middot;
                     <a target="_blank" rel="noopener noreferrer" href="https://github.com/WesleyyC">GitHub</a>
                 </div>
             </div>
@@ -308,7 +311,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Student Researcher | <a target="_blank" rel="noopener noreferrer" href="https://research.google/" class="brand-link"><span class="google-g">G</span><span class="google-o1">o</span><span class="google-o2">o</span><span class="google-g2">g</span><span class="google-l">l</span><span class="google-e">e</span></a></div>
+                <div class="entry-title">Student Researcher | <a target="_blank" rel="noopener noreferrer" href="https://research.google/"><span class="google-g">G</span><span class="google-o1">o</span><span class="google-o2">o</span><span class="google-g2">g</span><span class="google-l">l</span><span class="google-e">e</span></a></div>
                 <div class="entry-date">May 2018 - Sep 2022</div>
             </div>
             <ul class="bullets">
@@ -320,7 +323,7 @@ permalink: /resume
 
         <div class="no-break">
             <div class="entry-header">
-                <div class="entry-title">Intern | <a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue brand-link-bold">DeepMind</a></div>
+                <div class="entry-title">Intern | <a target="_blank" rel="noopener noreferrer" href="https://deepmind.google/" class="deepmind-blue" style="font-weight:700">DeepMind</a></div>
                 <div class="entry-date">Sep 2021 - Dec 2021</div>
             </div>
             <ul class="bullets">

--- a/resume.html
+++ b/resume.html
@@ -73,11 +73,11 @@ permalink: /resume
         }
 
         .header h1 {
-            font-size: 24pt;
+            font-size: 28pt;
             font-weight: 700;
             color: var(--color-text-dark);
-            line-height: 1.1;
-            letter-spacing: -0.01em;
+            line-height: 1.05;
+            letter-spacing: -0.02em;
             transition: transform 0.2s var(--ease-out-quart), text-shadow 0.2s ease;
             cursor: default;
         }
@@ -106,12 +106,14 @@ permalink: /resume
 
         /* --- Section Headers --- */
         h2 {
-            font-size: 15pt;
-            font-weight: 400;
+            font-size: 11pt;
+            font-weight: 600;
             color: var(--color-text);
-            border-bottom: 1.5pt solid var(--color-accent);
-            padding-bottom: 2pt;
-            margin-top: 0.12in;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            border-bottom: 2pt solid var(--color-accent);
+            padding-bottom: 3pt;
+            margin-top: 0.14in;
             margin-bottom: 0.06in;
         }
 
@@ -124,7 +126,7 @@ permalink: /resume
         }
 
         .entry-title {
-            font-size: 11pt;
+            font-size: 11.5pt;
             font-weight: 700;
         }
 
@@ -144,7 +146,7 @@ permalink: /resume
         .entry-title a.brandeis-blue:hover { color: #002a60; }
 
         .entry-date {
-            font-size: 11pt;
+            font-size: 10.5pt;
             white-space: nowrap;
             color: var(--color-text-muted);
         }
@@ -246,9 +248,11 @@ permalink: /resume
         }
 
         .pub-note {
-            font-size: 10pt;
+            font-size: 9pt;
             font-weight: 400;
             color: var(--color-text-light);
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         /* --- Services (grey bullets like publications) --- */

--- a/resume.html
+++ b/resume.html
@@ -10,26 +10,39 @@ permalink: /resume
     <title>Wesley Wei Qian - Resume</title>
     <link rel="shortcut icon" href="/img/logo/logo.ico">
     <style>
-        /* --- Reset & Base --- */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             font-size: 10pt;
             line-height: 1.4;
-            color: #333;
-            background: #e8e8e8;
+            color: #2d2d2d;
+            background: #e4e4e4;
             -webkit-print-color-adjust: exact;
             print-color-adjust: exact;
         }
 
         .page {
             width: 8.5in;
+            max-width: 100%;
             min-height: 11in;
             margin: 0.4in auto;
             padding: 0.5in 0.6in;
             background: #fff;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+            box-shadow: 0 1px 6px rgba(0,0,0,0.12);
+        }
+
+        /* --- Focus & Accessibility --- */
+        a:focus-visible {
+            outline: 2px solid #2AA198;
+            outline-offset: 2px;
+            border-radius: 2px;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                transition: none !important;
+            }
         }
 
         /* --- Header --- */
@@ -37,25 +50,27 @@ permalink: /resume
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.1in;
+            margin-bottom: 0.08in;
         }
 
         .header h1 {
             font-size: 24pt;
             font-weight: 700;
-            color: #222;
+            color: #1a1a1a;
             line-height: 1.1;
+            letter-spacing: -0.01em;
         }
 
         .contact {
             text-align: right;
             font-size: 10pt;
-            line-height: 1.5;
+            line-height: 1.6;
         }
 
         .contact a {
-            color: #333;
+            color: #2d2d2d;
             text-decoration: none;
+            transition: color 0.15s ease;
         }
 
         .contact a:hover { text-decoration: underline; }
@@ -65,11 +80,13 @@ permalink: /resume
             text-decoration: underline;
         }
 
+        .contact .links a:hover { color: #208a82; }
+
         /* --- Section Headers --- */
         h2 {
-            font-size: 16pt;
+            font-size: 15pt;
             font-weight: 300;
-            color: #333;
+            color: #2d2d2d;
             border-bottom: 1.5pt solid #2AA198;
             padding-bottom: 2pt;
             margin-top: 0.12in;
@@ -93,18 +110,21 @@ permalink: /resume
 
         .entry-title a {
             text-decoration: none;
+            transition: opacity 0.15s ease;
         }
+
+        .entry-title a:hover { opacity: 0.7; }
 
         .entry-date {
             font-size: 10pt;
             white-space: nowrap;
-            color: #555;
+            color: #666;
         }
 
-        /* Brand colors */
+        /* --- Brand Colors --- */
         .google-g { color: #4285F4; }
         .google-o1 { color: #EA4335; }
-        .google-o2 { color: #FBBC05; }
+        .google-o2 { color: #E2A000; }
         .google-g2 { color: #4285F4; }
         .google-l { color: #34A853; }
         .google-e { color: #EA4335; }
@@ -114,8 +134,13 @@ permalink: /resume
         .brand-link { text-decoration: none; font-weight: 400; }
         .brand-link-bold { text-decoration: none; font-weight: 700; }
 
-        .teal-link { color: #2AA198; text-decoration: none; font-weight: 700; }
-        .teal-link:hover { text-decoration: underline; }
+        .teal-link {
+            color: #2AA198;
+            text-decoration: none;
+            font-weight: 700;
+            transition: color 0.15s ease;
+        }
+        .teal-link:hover { color: #208a82; text-decoration: underline; }
 
         /* --- Bullet Lists --- */
         .bullets {
@@ -135,23 +160,21 @@ permalink: /resume
             content: "\2023";
             position: absolute;
             left: 0;
+            color: #555;
         }
 
         .bullets a {
-            color: #333;
+            color: #2d2d2d;
             text-decoration: underline;
+            text-underline-offset: 1.5pt;
+            transition: color 0.15s ease;
         }
+
+        .bullets a:hover { color: #2AA198; }
 
         /* --- Education --- */
         .edu-entry { margin-bottom: 0.04in; }
-
-        .edu-entry .degree {
-            font-style: italic;
-        }
-
-        .edu-entry .details {
-            font-size: 10pt;
-        }
+        .edu-entry .degree { font-style: italic; }
 
         /* --- Publications --- */
         .pub {
@@ -164,49 +187,46 @@ permalink: /resume
             content: "\2023";
             position: absolute;
             left: 0;
+            color: #555;
         }
 
-        .pub .pub-title {
-            font-weight: 700;
-        }
+        .pub .pub-title { font-weight: 700; }
 
         .pub .pub-venue {
-            text-decoration: underline;
             font-style: italic;
         }
 
         .pub .pub-venue a {
             color: inherit;
             text-decoration: underline;
+            text-underline-offset: 1.5pt;
+            transition: color 0.15s ease;
         }
 
-        .pub .pub-year {
-            font-style: normal;
-        }
+        .pub .pub-venue a:hover { color: #2AA198; }
+
+        .pub .pub-year { font-style: normal; }
 
         .pub .pub-authors {
-            padding-left: 0.25in;
+            padding-left: 0.12in;
             font-size: 9.5pt;
+            color: #444;
         }
 
         .pub .pub-authors .me {
             font-weight: 700;
+            color: #2d2d2d;
         }
 
         .pub-note {
             font-size: 10pt;
-            color: #555;
-            margin-bottom: 0.08in;
+            font-weight: 300;
+            color: #666;
         }
 
         /* --- Page Break Helpers --- */
-        .page-break-before {
-            break-before: page;
-        }
-
-        .no-break {
-            break-inside: avoid;
-        }
+        .page-break-before { break-before: page; }
+        .no-break { break-inside: avoid; }
 
         /* --- Print Styles --- */
         @page {
@@ -215,9 +235,7 @@ permalink: /resume
         }
 
         @media print {
-            body {
-                background: none;
-            }
+            body { background: none; }
 
             .page {
                 width: auto;
@@ -228,20 +246,18 @@ permalink: /resume
             }
 
             a { color: inherit; }
-            .contact a, .contact .links a { color: #333; }
+            .contact a, .contact .links a { color: #2d2d2d; }
             .teal-link { color: #2AA198; }
             .deepmind-blue { color: #0F4ABE; }
 
-            .page-break-before {
-                padding-top: 0.3in;
-            }
+            .page-break-before { padding-top: 0.3in; }
         }
     </style>
 </head>
 <body>
-    <div class="page">
+    <main class="page">
         <!-- HEADER -->
-        <div class="header">
+        <header class="header">
             <h1>Wesley Wei Qian</h1>
             <div class="contact">
                 <div><a href="mailto:wesley.chin0919@gmail.com">wesley.chin0919@gmail.com</a></div>
@@ -252,9 +268,10 @@ permalink: /resume
                     <a target="_blank" rel="noopener noreferrer" href="https://github.com/WesleyyC">GitHub</a>
                 </div>
             </div>
-        </div>
+        </header>
 
         <!-- EXPERIENCE -->
+        <section aria-label="Experience">
         <h2>Experience</h2>
 
         <div class="no-break">
@@ -277,7 +294,7 @@ permalink: /resume
                 <div class="entry-date">May 2018 - Sep 2022</div>
             </div>
             <ul class="bullets">
-                <li><strong>Olfactory ML:</strong> Advanced receptor binding prediction and metabolic activity modeling, resulting in one <u>utility patent</u> and four publications featured <a target="_blank" rel="noopener noreferrer" href="https://ai.googleblog.com/2022/09/digitizing-smell-using-molecular-maps.html">in</a> <a target="_blank" rel="noopener noreferrer" href="https://www.quantamagazine.org/ai-model-links-smell-molecules-with-metabolic-processes-20221010/">major</a> <a target="_blank" rel="noopener noreferrer" href="https://www.scientificamerican.com/article/ai-predicts-what-chemicals-will-smell-like-to-a-human/">news</a> <a target="_blank" rel="noopener noreferrer" href="https://blog.google/technology/research/using-new-technology-and-old-books-to-combat-disease/">outlets</a>, catalyzing Osmo's spin out.</li>
+                <li><strong>Olfactory ML:</strong> Advanced receptor binding prediction and metabolic activity modeling, resulting in one utility patent and four publications featured <a target="_blank" rel="noopener noreferrer" href="https://ai.googleblog.com/2022/09/digitizing-smell-using-molecular-maps.html">in</a> <a target="_blank" rel="noopener noreferrer" href="https://www.quantamagazine.org/ai-model-links-smell-molecules-with-metabolic-processes-20221010/">major</a> <a target="_blank" rel="noopener noreferrer" href="https://www.scientificamerican.com/article/ai-predicts-what-chemicals-will-smell-like-to-a-human/">news</a> <a target="_blank" rel="noopener noreferrer" href="https://blog.google/technology/research/using-new-technology-and-old-books-to-combat-disease/">outlets</a>, catalyzing Osmo's spin out.</li>
                 <li><strong>Genomics &amp; Structural Variants:</strong> Proposed a combinatorial formulation for structural variant calling with ML-based filtering; engineered a ~100× faster read-alignment approach, filed as <a target="_blank" rel="noopener noreferrer" href="https://patents.google.com/patent/WO2022165430A1">a utility patent.</a></li>
                 <li><strong>Generative Cell Images:</strong> Developed a GAN to mitigate batch effects in high-content cell imaging; upstreamed implementations to the <a target="_blank" rel="noopener noreferrer" href="https://blog.tensorflow.org/2019/08/introducing-tf-gan-lightweight-gan.html">TF-GAN library</a> and published findings in Bioinformatics.</li>
             </ul>
@@ -303,8 +320,10 @@ permalink: /resume
                 <li><strong>[2016] Mobile Dev. &amp; Engineering:</strong> Developed a web-based forensics tool for mobile UI testing that synchronized logs with video timestamps, reducing internal developer debugging time by ~50%.</li>
             </ul>
         </div>
+        </section>
 
         <!-- EDUCATION -->
+        <section aria-label="Education">
         <h2>Education</h2>
 
         <div class="edu-entry no-break">
@@ -313,8 +332,8 @@ permalink: /resume
                 <div class="entry-date">2017 - 2022</div>
             </div>
             <div class="degree">Doctor of Philosophy in Computer Science</div>
-            <div class="details">Dissertation: Machine learning for drug discovery and beyond (advisor: <em>Jian Peng</em>)</div>
-            <div class="details">GPA: 4.00 / 4.00 | University Fellowship | Richard T. Cheng Endowed Fellowship</div>
+            <div>Dissertation: Machine learning for drug discovery and beyond (advisor: <em>Jian Peng</em>)</div>
+            <div>GPA: 4.00 / 4.00 | University Fellowship | Richard T. Cheng Endowed Fellowship</div>
         </div>
 
         <div class="edu-entry no-break">
@@ -323,16 +342,18 @@ permalink: /resume
                 <div class="entry-date">2013 - 2017</div>
             </div>
             <div class="degree">Bachelor of Science in Computer Science and Neuroscience</div>
-            <div class="details">GPA: 3.96 / 4.00 | Summa Cum Laude | Phi Beta Kappa (Junior) | Schiff Fellowship</div>
+            <div>GPA: 3.96 / 4.00 | Summa Cum Laude | Phi Beta Kappa (Junior) | Schiff Fellowship</div>
         </div>
+        </section>
 
         <!-- RECENT & SELECTED PUBLICATIONS -->
+        <section aria-label="Recent and Selected Publications">
         <h2 class="page-break-before">Recent &amp; Selected Publications <span class="pub-note">(*equal contribution)</span></h2>
 
         <div class="pub no-break">
             <div><span class="pub-title">New York Smells: A Large Multimodal Dataset for Olfaction</span></div>
             <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://arxiv.org/abs/2511.20544">arXiv</a></span> <span class="pub-year">(2025)</span></div>
-            <div class="pub-authors">Ege Ozguroglu, Junbang Liang, Ruoshi Liu, Mia Chiquier, Michael DeTienne, <span class="me">Wesley W.Qian</span>, Alexandra Horowitz, Andrew Owens, Carl Vondrick</div>
+            <div class="pub-authors">Ege Ozguroglu, Junbang Liang, Ruoshi Liu, Mia Chiquier, Michael DeTienne, <span class="me">Wesley W. Qian</span>, Alexandra Horowitz, Andrew Owens, Carl Vondrick</div>
         </div>
 
         <div class="pub no-break">
@@ -376,16 +397,20 @@ permalink: /resume
             <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://academic.oup.com/bioinformatics/article/36/Supplement_2/i875/6055901">Bioinformatics</a></span> <span class="pub-year">(2020)</span></div>
             <div class="pub-authors"><span class="me">Wesley W. Qian</span>, Cassandra Xia, Subhashini Venugopalan, Arunachalam Narayanaswamy, Michelle Dimon, George W. Ashdown, Jake Baum, Jian Peng, D Michael Ando</div>
         </div>
+        </section>
 
         <!-- SERVICES -->
+        <section aria-label="Services">
         <h2>Services</h2>
 
         <ul class="bullets">
             <li><strong>Reviewer</strong> for Nature Machine Intelligence (2025), ICML (2024), ICLR (2024), NeurIPS (2023), LoG (2022 &amp; 2023), RECOMB (2021), ISMB (2019 &amp; 2020)</li>
             <li><strong>Program Committee</strong> for ICML - ML Interpretability for Scientific Discovery Workshop 2020</li>
         </ul>
+        </section>
 
         <!-- OTHER PUBLICATION -->
+        <section aria-label="Other Publications">
         <h2 class="page-break-before">Other Publication</h2>
 
         <div class="pub no-break">
@@ -423,6 +448,7 @@ permalink: /resume
             <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://dl.acm.org/doi/10.1007/978-3-030-45257-5_30">RECOMB</a></span> <span class="pub-year">(2020)</span></div>
             <div class="pub-authors">Yunan Luo, Lam Vo, Hantian Ding, Yufeng Su, Yang Liu, <span class="me">Wesley W. Qian</span>, Huimin Zhao, Jian Peng</div>
         </div>
-    </div>
+        </section>
+    </main>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -98,7 +98,7 @@ permalink: /resume
         }
 
         .entry-title {
-            font-size: 10.5pt;
+            font-size: 11pt;
             font-weight: 700;
         }
 
@@ -114,8 +114,11 @@ permalink: /resume
         .entry-title a.teal-link { color: #2AA198; }
         .entry-title a.teal-link:hover { color: #208a82; }
 
+        .uiuc-orange { color: #E05500; }
+        .brandeis-blue { color: #003478; }
+
         .entry-date {
-            font-size: 10.5pt;
+            font-size: 11pt;
             white-space: nowrap;
             color: #666;
         }
@@ -249,6 +252,8 @@ permalink: /resume
             .entry-title a { color: #1a1a1a; }
             .teal-link { color: #2AA198; }
             .deepmind-blue { color: #0F4ABE; }
+            .uiuc-orange { color: #E05500; }
+            .brandeis-blue { color: #003478; }
 
             .page-break-before { padding-top: 0.3in; }
         }
@@ -325,7 +330,7 @@ permalink: /resume
 
         <div class="edu-entry no-break">
             <div class="entry-header">
-                <div class="entry-title"><a class="teal-link" target="_blank" rel="noopener noreferrer" href="https://cs.illinois.edu/">University of Illinois Urbana Champaign</a></div>
+                <div class="entry-title"><a class="uiuc-orange" target="_blank" rel="noopener noreferrer" href="https://cs.illinois.edu/" style="text-decoration:none;font-weight:700">University of Illinois Urbana Champaign</a></div>
                 <div class="entry-date">2017 - 2022</div>
             </div>
             <div class="degree">Doctor of Philosophy in Computer Science</div>
@@ -335,7 +340,7 @@ permalink: /resume
 
         <div class="edu-entry no-break">
             <div class="entry-header">
-                <div class="entry-title"><a class="teal-link" target="_blank" rel="noopener noreferrer" href="https://www.brandeis.edu/">Brandeis University</a></div>
+                <div class="entry-title"><a class="brandeis-blue" target="_blank" rel="noopener noreferrer" href="https://www.brandeis.edu/" style="text-decoration:none;font-weight:700">Brandeis University</a></div>
                 <div class="entry-date">2013 - 2017</div>
             </div>
             <div class="degree">Bachelor of Science in Computer Science and Neuroscience</div>
@@ -396,7 +401,7 @@ permalink: /resume
         </section>
 
         <section aria-label="Other Publications">
-        <h2 class="page-break-before">Other Publication</h2>
+        <h2>Other Publication</h2>
 
         <div class="pub no-break">
             <div><span class="pub-title">Pervasive mislocalization of pathogenic coding variants underlying human disorders</span></div>

--- a/resume.html
+++ b/resume.html
@@ -69,7 +69,7 @@ permalink: /resume
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.06in;
+            margin-bottom: 0.08in;
         }
 
         .header h1 {
@@ -128,6 +128,7 @@ permalink: /resume
         .entry-title {
             font-size: 11.5pt;
             font-weight: 700;
+            color: #444;
         }
 
         .entry-title a {
@@ -147,8 +148,10 @@ permalink: /resume
 
         .entry-date {
             font-size: 10.5pt;
+            font-weight: 400;
             white-space: nowrap;
-            color: var(--color-text-muted);
+            color: #5a5a5a;
+            font-style: italic;
         }
 
         /* --- Brand Colors --- */


### PR DESCRIPTION
## Summary
- Create self-contained HTML resume at `/resume` replacing PDF as source of truth
- Source Sans 3 font, CSS design tokens, semantic HTML with aria labels
- Print-to-PDF via Chrome produces clean 3-page output (no headers/footers)
- All hyperlinks extracted from original PDF (publications, company sites, patents)
- Brand colors: Google rainbow, DeepMind blue, UIUC orange, Brandeis blue
- Distinct bullet styles: teal arrows (experience) vs grey dots (publications/services)
- Uppercase letterspaced section headers for architectural feel
- Update `_config.yml` resume link from PDF to `/resume`
- Multiple impeccable passes: audit, critique, polish, normalize, delight, bolder

## Test plan
- [ ] Open `drq.ai/resume` in browser — verify layout and styling
- [ ] Cmd+P in Chrome (margins: None) — verify 3 clean pages, no title/timestamp
- [ ] Click all links — verify they open in new tabs
- [ ] Compare with original `rsc/resume.pdf` for content accuracy
- [ ] Check brand colors render correctly in print

🤖 Generated with [Claude Code](https://claude.com/claude-code)