### PR TITLE
fix(resume): update New York Smells paper link

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -386,7 +386,7 @@ permalink: /resume
 
         <div class="pub no-break">
             <div><span class="pub-title">New York Smells: A Large Multimodal Dataset for Olfaction</span></div>
-            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://arxiv.org/abs/2511.20544">arXiv</a></span> <span class="pub-year">(2025)</span></div>
+            <div><span class="pub-venue"><a target="_blank" rel="noopener noreferrer" href="https://smell.cs.columbia.edu/">arXiv</a></span> <span class="pub-year">(2025)</span></div>
             <div class="pub-authors">Ege Ozguroglu, Junbang Liang, Ruoshi Liu, Mia Chiquier, Michael DeTienne, <span class="me">Wesley W. Qian</span>, Alexandra Horowitz, Andrew Owens, Carl Vondrick</div>
         </div>
 


### PR DESCRIPTION
## Summary
- Updated the New York Smells paper link from arXiv to the project page (https://smell.cs.columbia.edu/)

## Test plan
- [ ] Verify the link works on the live resume page at /resume
- [ ] Confirm print-to-PDF still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)